### PR TITLE
Fix: Default `attributes_for_select` to an empty array if no translation found

### DIFF
--- a/lib/translateable_attributes/methods.rb
+++ b/lib/translateable_attributes/methods.rb
@@ -11,7 +11,9 @@ module TranslateableAttributes
         end
 
         define_singleton_method "#{plural_attribute}_for_select" do
-          I18n.t(namespace).each_with_object([]) do |(value, translation), collection|
+          options = I18n.t(namespace, default: nil) || []
+
+          options.each_with_object([]) do |(value, translation), collection|
             collection << [translation, value]
           end
         end


### PR DESCRIPTION
This fixes an issue with using this gem in a Rails application. 

In cases where a class that uses `translateable_attributes` needs to be loaded before the eager loading process, `attributes_for_select` usage will raise `NoMethodError: undefined method 'each_with_object' for #<String>` since I18n translations haven't been loaded yet.